### PR TITLE
Adjusting to bypass the import-error problem.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,4 @@
+# Workaround to resolve the import problem that Pylint shows.
+[MASTER]
+init-hook="from pylint.config import find_pylintrc;
+import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"


### PR DESCRIPTION
<!--
All things inside the blocks like this are not visible by the users, but only when editing the ticket.

Access the `Preview` tab to see what happens.
-->

# Related Issues
<!--
Issues goes here using the pattern `Fix #[issueNumber]`.

Example:
- Fix #1

It will close the `Issues` related by this `Pull Request`.
-->
- Fix #47

# Affected changes
<!--
To mark an item, replace the `space` by an `x` inside the `brackets`.

Example:
- [x] Marked item
- [ ] Unmarked item
-->

- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [x] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

# Proposed Changes
- Created the file .pylintrc with the code that changes the sys.path used by Python to search for modules relative to the base folder of project.

# Additional Info
The problem "Unable to import 'window'pylint(import-error)" occurs because Pylint can't find the base folder of the project.

This is explained better on http://wgundamj44.github.io/post/2015-10-23-pylint-import-error-in-django/.

The better solution was found on https://stackoverflow.com/a/59809409/4079049.

# Checklist
<!--
To mark a item, replace the `space` by an `x` inside the `brackets`.

Example:
- [x] Marked item
- [ ] Unmarked item
-->

- [x] Tests.
- [ ] Translations.
- [ ] Documentation.

# Screenshots

Original | Updated
:-:|:-:
![image](https://user-images.githubusercontent.com/34061128/130332577-37526e6f-9d99-4092-8706-b6e2bb110bbf.png) | ![image](https://user-images.githubusercontent.com/34061128/130333045-a605d09b-f70d-4c76-b713-df61de923ce2.png)